### PR TITLE
Add Dockerized microservices and infrastructure scaffolding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.9"
+services:
+  booking:
+    build: ./services/booking
+    ports:
+      - "8000:8000"
+    environment:
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+  users:
+    build: ./services/users
+    ports:
+      - "8001:8000"
+    environment:
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,37 @@
+# Development Guide
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Terraform](https://developer.hashicorp.com/terraform/downloads)
+- Python 3.11+
+- AWS credentials configured for access to CloudWatch, RDS and S3
+
+## Getting Started
+
+1. Clone the repository and change into the directory.
+2. Run `scripts/setup.sh` to create a virtual environment, install dependencies and start the microservices with Docker Compose.
+3. Access the services:
+   - Booking service: `http://localhost:8000`
+   - User service: `http://localhost:8001`
+
+Logs are emitted in JSON format and, when AWS credentials are available, forwarded to CloudWatch.
+
+## Infrastructure
+
+Terraform configuration in `infra/` provisions:
+
+- ECS cluster for running containers
+- RDS PostgreSQL instance
+- S3 bucket for application assets
+- CloudWatch log group for service logs
+
+To deploy infrastructure:
+
+```bash
+cd infra
+terraform init
+terraform apply
+```
+
+This will create resources in the AWS account configured in your environment.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "aws_ecs_cluster" "homestays" {
+  name = var.cluster_name
+}
+
+resource "aws_db_instance" "homestays" {
+  identifier         = var.db_identifier
+  allocated_storage  = 20
+  engine             = "postgres"
+  instance_class     = "db.t3.micro"
+  username           = var.db_username
+  password           = var.db_password
+  skip_final_snapshot = true
+}
+
+resource "aws_s3_bucket" "homestays" {
+  bucket = var.bucket_name
+}
+
+resource "aws_cloudwatch_log_group" "services" {
+  name = "/homestays/services"
+  retention_in_days = 7
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,35 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "cluster_name" {
+  description = "ECS cluster name"
+  type        = string
+  default     = "homestays-cluster"
+}
+
+variable "db_identifier" {
+  description = "RDS instance identifier"
+  type        = string
+  default     = "homestays-db"
+}
+
+variable "db_username" {
+  description = "Database username"
+  type        = string
+  default     = "admin"
+}
+
+variable "db_password" {
+  description = "Database password"
+  type        = string
+  default     = "changeme"
+}
+
+variable "bucket_name" {
+  description = "S3 bucket name"
+  type        = string
+  default     = "homestays-bucket"
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Setting up development environment..."
+
+python3 -m venv venv
+source venv/bin/activate
+pip install -r services/booking/requirements.txt -r services/users/requirements.txt
+
+echo "Building and starting services with Docker Compose..."
+docker compose up --build -d
+
+echo "Environment is ready."

--- a/services/booking/Dockerfile
+++ b/services/booking/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+EXPOSE 8000
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/booking/app.py
+++ b/services/booking/app.py
@@ -1,0 +1,29 @@
+import logging
+from fastapi import FastAPI
+from pythonjsonlogger import jsonlogger
+import watchtower
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+stream_handler = logging.StreamHandler()
+stream_handler.setFormatter(jsonlogger.JsonFormatter())
+logger.addHandler(stream_handler)
+
+try:
+    cw_handler = watchtower.CloudWatchLogHandler(log_group="/homestays/services", stream_name="booking-service")
+    cw_handler.setFormatter(jsonlogger.JsonFormatter())
+    logger.addHandler(cw_handler)
+except Exception as e:
+    logger.warning("Unable to initialize CloudWatch log handler", extra={"error": str(e)})
+
+app = FastAPI()
+
+@app.get("/")
+async def root():
+    logger.info("root accessed", extra={"service": "booking"})
+    return {"service": "booking", "message": "Hello World"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/booking/requirements.txt
+++ b/services/booking/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+watchtower
+python-json-logger

--- a/services/users/Dockerfile
+++ b/services/users/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+EXPOSE 8000
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/users/app.py
+++ b/services/users/app.py
@@ -1,0 +1,29 @@
+import logging
+from fastapi import FastAPI
+from pythonjsonlogger import jsonlogger
+import watchtower
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+stream_handler = logging.StreamHandler()
+stream_handler.setFormatter(jsonlogger.JsonFormatter())
+logger.addHandler(stream_handler)
+
+try:
+    cw_handler = watchtower.CloudWatchLogHandler(log_group="/homestays/services", stream_name="user-service")
+    cw_handler.setFormatter(jsonlogger.JsonFormatter())
+    logger.addHandler(cw_handler)
+except Exception as e:
+    logger.warning("Unable to initialize CloudWatch log handler", extra={"error": str(e)})
+
+app = FastAPI()
+
+@app.get("/")
+async def root():
+    logger.info("root accessed", extra={"service": "user"})
+    return {"service": "user", "message": "Hello World"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/users/requirements.txt
+++ b/services/users/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+watchtower
+python-json-logger


### PR DESCRIPTION
## Summary
- containerize booking and user microservices with JSON logging and CloudWatch shipping
- add Terraform config for ECS cluster, RDS, S3 bucket, and log group
- document development setup and provide onboarding script

## Testing
- `python -m py_compile services/booking/app.py services/users/app.py`
- `docker compose config` *(fails: command not found)*
- `terraform version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5959f41ec8331b5c798e1db4cb86d