### PR TITLE
Add basic testing scaffolding

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,32 @@
+# Testing Guide
+
+## Service
+1. Install dependencies:
+   ```bash
+   cd service
+   npm install
+   ```
+2. Run unit tests:
+   ```bash
+   npm test
+   ```
+3. Run integration tests:
+   ```bash
+   npm run test:integration
+   ```
+4. Run contract tests:
+   ```bash
+   npm run test:contract
+   ```
+
+## UI Tests
+1. Install dependencies:
+   ```bash
+   cd ui
+   npm install
+   npx playwright install chromium
+   ```
+2. Run UI tests:
+   ```bash
+   npm test
+   ```

--- a/service/jest.config.js
+++ b/service/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testMatch: ['**/tests/unit/**/*.test.js']
+};

--- a/service/package.json
+++ b/service/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "service",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest",
+    "test:integration": "newman run tests/integration/echo.postman_collection.json",
+    "test:contract": "newman run tests/contract/contract.postman_collection.json"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "newman": "^5.0.0"
+  }
+}

--- a/service/tests/contract/contract.postman_collection.json
+++ b/service/tests/contract/contract.postman_collection.json
@@ -1,0 +1,28 @@
+{
+  "info": {
+    "name": "Contract Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Get Echo Contract",
+      "request": {
+        "method": "GET",
+        "url": "https://postman-echo.com/get"
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('status is 200', function () {",
+              "    pm.response.to.have.status(200);",
+              "});"
+            ]
+          }
+        }
+      ],
+      "response": []
+    }
+  ]
+}

--- a/service/tests/integration/echo.postman_collection.json
+++ b/service/tests/integration/echo.postman_collection.json
@@ -1,0 +1,16 @@
+{
+  "info": {
+    "name": "Echo Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Get Echo",
+      "request": {
+        "method": "GET",
+        "url": "https://postman-echo.com/get"
+      },
+      "response": []
+    }
+  ]
+}

--- a/service/tests/unit/sample.test.js
+++ b/service/tests/unit/sample.test.js
@@ -1,0 +1,5 @@
+describe('sample test', () => {
+  test('1 + 1 equals 2', () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "ui-tests",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.44.0"
+  }
+}

--- a/ui/playwright.config.js
+++ b/ui/playwright.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testDir: './tests'
+};

--- a/ui/tests/example.spec.js
+++ b/ui/tests/example.spec.js
@@ -1,0 +1,6 @@
+const { test, expect } = require('@playwright/test');
+
+test('homepage has title', async ({ page }) => {
+  await page.goto('https://example.com');
+  await expect(page).toHaveTitle(/Example Domain/);
+});


### PR DESCRIPTION
## Summary
- add service test frameworks with Jest and Newman placeholders
- scaffold Playwright UI tests
- document test execution steps in TESTING.md

## Testing
- `npm install` *(failed: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm test` *(failed: sh: 1: jest: not found)*
- `npm run test:integration` *(failed: sh: 1: newman: not found)*
- `npm run test:contract` *(failed: sh: 1: newman: not found)*
- `npm install` (ui) *(failed: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*
- `npx playwright install chromium` *(failed: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm test` (ui) *(failed: sh: 1: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5957e83008331bc66f9b4a3b2558c