### PR TITLE
Add environment-based config and startup scripts

### DIFF
--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -1,0 +1,40 @@
+# Environment Provisioning
+
+This project uses a central configuration store backed by AWS SSM Parameter Store.  
+Configuration is organized by environment and service. Each environment has a YAML file under `config/` 
+that maps services to their parameter paths in SSM.
+
+## Environments
+
+- **dev-integration** – Used for local integration testing across services.
+- **dev-staging** – Mirrors production with staging data for final validation.
+- **dev-production** – Production configuration.
+
+## Provisioning Parameters
+
+Parameters are stored in SSM using the following pattern:
+
+```
+/homestaysofhimalaya/<environment>/<service>/<parameter>
+```
+
+For example, the booking service database URL for the integration environment is stored at:
+
+```
+/homestaysofhimalaya/dev-integration/booking/database_url
+```
+
+Parameters should be created with `--type SecureString` for sensitive values.
+
+## Using Configuration
+
+Service startup scripts read `APP_ENV` to determine which config file to load. The script then pulls the
+appropriate parameter values from SSM before launching the service.
+
+To start the booking service in the staging environment:
+
+```bash
+APP_ENV=dev-staging services/booking/start.sh
+```
+
+Ensure the IAM role or AWS credentials used by the service allow `ssm:GetParameter` access.

--- a/config/dev-integration.yml
+++ b/config/dev-integration.yml
@@ -1,0 +1,6 @@
+booking:
+  database_url: "/homestaysofhimalaya/dev-integration/booking/database_url"
+  redis_url: "/homestaysofhimalaya/dev-integration/booking/redis_url"
+payments:
+  database_url: "/homestaysofhimalaya/dev-integration/payments/database_url"
+  redis_url: "/homestaysofhimalaya/dev-integration/payments/redis_url"

--- a/config/dev-production.yml
+++ b/config/dev-production.yml
@@ -1,0 +1,6 @@
+booking:
+  database_url: "/homestaysofhimalaya/dev-production/booking/database_url"
+  redis_url: "/homestaysofhimalaya/dev-production/booking/redis_url"
+payments:
+  database_url: "/homestaysofhimalaya/dev-production/payments/database_url"
+  redis_url: "/homestaysofhimalaya/dev-production/payments/redis_url"

--- a/config/dev-staging.yml
+++ b/config/dev-staging.yml
@@ -1,0 +1,6 @@
+booking:
+  database_url: "/homestaysofhimalaya/dev-staging/booking/database_url"
+  redis_url: "/homestaysofhimalaya/dev-staging/booking/redis_url"
+payments:
+  database_url: "/homestaysofhimalaya/dev-staging/payments/database_url"
+  redis_url: "/homestaysofhimalaya/dev-staging/payments/redis_url"

--- a/scripts/start_service.sh
+++ b/scripts/start_service.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE="$1"
+APP_ENV="${APP_ENV:-dev-integration}"
+CONFIG_FILE="config/${APP_ENV}.yml"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "Config file $CONFIG_FILE not found" >&2
+  exit 1
+fi
+
+fetch_param() {
+  local key="$1"
+  python - <<PY
+import yaml,sys
+with open("$CONFIG_FILE") as f:
+    data=yaml.safe_load(f)
+print(data.get("$SERVICE", {}).get("$key", ""))
+PY
+}
+
+DB_PARAM=$(fetch_param database_url)
+REDIS_PARAM=$(fetch_param redis_url)
+
+if [ -z "$DB_PARAM" ] || [ -z "$REDIS_PARAM" ]; then
+  echo "Missing parameter paths for $SERVICE in $CONFIG_FILE" >&2
+  exit 1
+fi
+
+DB_URL=$(aws ssm get-parameter --name "$DB_PARAM" --with-decryption --output text --query Parameter.Value)
+REDIS_URL=$(aws ssm get-parameter --name "$REDIS_PARAM" --with-decryption --output text --query Parameter.Value)
+
+export DB_URL REDIS_URL
+
+echo "Starting $SERVICE with configuration from $CONFIG_FILE"
+# Placeholder for actual service command
+exec "./$SERVICE" "$@"

--- a/services/booking/start.sh
+++ b/services/booking/start.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_ENV="${APP_ENV:-dev-integration}"
+"${SCRIPT_DIR}/../../scripts/start_service.sh" booking "$@"

--- a/services/payments/start.sh
+++ b/services/payments/start.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_ENV="${APP_ENV:-dev-integration}"
+"${SCRIPT_DIR}/../../scripts/start_service.sh" payments "$@"


### PR DESCRIPTION
## Summary
- introduce environment-scoped YAML config files backed by SSM parameter paths
- add shared startup script that loads configuration via AWS SSM Parameter Store
- document environment usage and provide service start scripts

## Testing
- `bash -n scripts/start_service.sh`
- `bash -n services/booking/start.sh`
- `bash -n services/payments/start.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b5959a098083319cd9eb45f3319eb2