### PR TITLE
Add Snyk scanning and Datadog monitoring

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,18 @@
+name: Security
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  snyk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: snyk/actions/setup@v1
+      - run: snyk test --severity-threshold=critical
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/datadog/dashboard.json
+++ b/datadog/dashboard.json
@@ -1,0 +1,29 @@
+{
+  "title": "Service Overview",
+  "description": "Key service metrics",
+  "layout_type": "ordered",
+  "widgets": [
+    {
+      "definition": {
+        "title": "Request latency (p95)",
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "avg:trace.http.request.duration{service:homestaysofhimalaya}.rollup(avg, 60)"
+          }
+        ]
+      }
+    },
+    {
+      "definition": {
+        "title": "Error rate",
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "100 * sum:trace.http.errors{service:homestaysofhimalaya}.rollup(sum, 60) / sum:trace.http.request{service:homestaysofhimalaya}.rollup(sum, 60)"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/datadog/monitors.json
+++ b/datadog/monitors.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "High request latency",
+    "type": "query alert",
+    "query": "avg(last_5m):p95:trace.http.request.duration{service:homestaysofhimalaya} > 1",
+    "message": "High latency detected. Notify @pagerduty",
+    "tags": ["service:homestaysofhimalaya", "env:prod"]
+  },
+  {
+    "name": "High error rate",
+    "type": "query alert",
+    "query": "avg(last_5m):sum:trace.http.errors{service:homestaysofhimalaya}/sum:trace.http.request{service:homestaysofhimalaya} > 0.05",
+    "message": "Error rate >5%. Notify @pagerduty",
+    "tags": ["service:homestaysofhimalaya", "env:prod"]
+  }
+]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.8'
+services:
+  web:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: ["node", "server.js"]
+    environment:
+      - DD_AGENT_HOST=datadog
+      - DD_ENV=production
+      - DD_SERVICE=homestaysofhimalaya
+      - DD_LOGS_ENABLED=true
+      - DD_APM_ENABLED=true
+      - DD_TRACE_AGENT_PORT=8126
+    depends_on:
+      - datadog
+    ports:
+      - "3000:3000"
+  datadog:
+    image: datadog/agent:7
+    environment:
+      - DD_API_KEY=${DD_API_KEY}
+      - DD_LOGS_ENABLED=true
+      - DD_APM_ENABLED=true
+      - DD_PROCESS_AGENT_ENABLED=true
+      - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
+    ports:
+      - "8126:8126"

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,40 @@
+# Monitoring and Alerting
+
+This project uses [Datadog](https://www.datadoghq.com/) for metrics, traces, and logs and runs [Snyk](https://snyk.io/) in CI to detect security issues.
+
+## Datadog Setup
+
+- The application runs alongside a Datadog agent defined in `docker-compose.yml`.
+- Metrics and traces are sent to the agent via environment variables such as `DD_AGENT_HOST` and `DD_SERVICE`.
+- Dashboards and monitors can be imported using the files in the `datadog/` directory.
+  - `dashboard.json` visualizes request latency and error rate.
+  - `monitors.json` defines alerts for high latency and high error rates.
+
+## Alerting Policies
+
+- **High request latency**
+  - Triggered when the 95th percentile of request latency exceeds 1 second over 5 minutes.
+  - Alerts notify the on-call engineer via PagerDuty.
+- **High error rate**
+  - Triggered when error rate exceeds 5% over 5 minutes.
+  - Alerts notify the on-call engineer via PagerDuty.
+
+## Response Runbooks
+
+### High request latency
+1. Confirm alert in Datadog and identify affected endpoints.
+2. Check recent deployments or infrastructure changes.
+3. Examine service logs for slow queries or external dependency issues.
+4. Mitigate by reverting recent changes or scaling resources.
+5. Once resolved, document the incident in the issue tracker.
+
+### High error rate
+1. Confirm alert and inspect error logs for stack traces.
+2. Roll back recent releases if a bug is suspected.
+3. Verify dependency availability (databases, external APIs).
+4. Communicate status to stakeholders until resolved.
+5. Record root cause and remediation steps.
+
+## Snyk in CI
+
+`Snyk` is executed in GitHub Actions (`.github/workflows/snyk.yml`) and fails the build on critical vulnerabilities.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "homestaysofhimalaya",
+  "version": "1.0.0",
+  "description": "Uttarakhand Homestays , bike &amp; car rentals booking and management.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node -e \"console.log('No tests')\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,18 @@
+const http = require('http');
+
+try {
+  require('dd-trace').init();
+  console.log('Datadog tracer initialized');
+} catch (err) {
+  console.warn('Datadog tracer not initialized:', err.message);
+}
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('Hello from homestaysofhimalaya');
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- run Snyk security scan in CI and fail on critical vulnerabilities
- add Datadog agent configuration with example dashboard and monitors
- document alerting policies and runbooks

## Testing
- `npm test`
- `npx snyk test` *(fails: 403 Forbidden retrieving snyk package)*

------
https://chatgpt.com/codex/tasks/task_e_68b5959ceeb883318389abf7d0bfad0d