### PR TITLE
Add OpenAPI spec, Swagger docs, and CI workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '18'
-      - run: npm ci
+      - run: npm install
       - run: npm run docs
       - uses: actions/upload-pages-artifact@v2
         with:


### PR DESCRIPTION
## Summary
- serve OpenAPI spec with Swagger UI
- document authentication usage and rate limits
- add CI workflow to build and publish API docs
- install dependencies in docs workflow without requiring a lockfile

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*
- `npm test`
- `npm run docs` *(fails: sh: 1: redoc-cli: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b598a887dc8331b1b715fb999c52ac