### PR TITLE
fix: mark RDS password variable as sensitive

### DIFF
--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -25,7 +25,7 @@ variable "db_username" {
 variable "db_password" {
   description = "Database password"
   type        = string
-  default     = "changeme"
+  sensitive   = true
 }
 
 variable "bucket_name" {


### PR DESCRIPTION
## Summary
- remove committed default value for `db_password`
- mark the Terraform variable as `sensitive` to avoid leaking secrets

## Testing
- `python -m py_compile services/booking/app.py services/users/app.py`
- `docker compose config` *(fails: command not found)*
- `terraform version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b598fc6e608331a9de4cb1041cf99b