### PR TITLE
Secure RDS password variable in Terraform configuration

### DIFF
--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -25,7 +25,7 @@ variable "db_username" {
 variable "db_password" {
   description = "Database password"
   type        = string
-  default     = "changeme"
+  sensitive   = true
 }
 
 variable "bucket_name" {


### PR DESCRIPTION
## Summary
- remove committed default password from `db_password`
- mark RDS password variable as sensitive so Terraform redacts it

## Testing
- `python -m py_compile services/booking/app.py services/users/app.py`
- `docker compose config` *(fails: command not found)*
- `terraform version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b59905c6b48331abb3fe7c6eaf3ec1