### PR TITLE
fix: exclude service name from forwarded args

### DIFF
--- a/scripts/start_service.sh
+++ b/scripts/start_service.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 SERVICE="$1"
+shift
 APP_ENV="${APP_ENV:-dev-integration}"
 CONFIG_FILE="config/${APP_ENV}.yml"
 


### PR DESCRIPTION
## Summary
- shift off the service name before forwarding script arguments

## Testing
- `bash -n scripts/start_service.sh`
- `bash -n services/booking/start.sh`
- `bash -n services/payments/start.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b59a53e0508331a721bc44b2cf4225