### PR TITLE
Add dd-trace dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "express": "^4.18.2",
     "swagger-ui-express": "^4.6.3",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "dd-trace": "^5.9.0"
   },
   "devDependencies": {
     "redoc-cli": "^0.13.14"


### PR DESCRIPTION
## Summary
- add dd-trace tracing library to application dependencies

## Testing
- `npm install --no-audit --no-fund --fetch-retries=0 --registry=https://registry.npmjs.org/` *(fails: ENETUNREACH)*
- `npm start` *(fails: Datadog tracer not initialized: Cannot find module 'dd-trace')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b69891d0c083319692a9bb3d84023b