### PR TITLE
docs: clean up README sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # HomestaysOfHimalaya
 
-Himalayan Homestays , bike & car rentals booking and management.
+Himalayan Homestays, bike & car rentals booking and management.
 
 ## Services
 - Booking service
 - User service
 
-A payments service is currently not implemented and related configuration has been removed.
-=======
-Himalayan Homestays , bike &amp; car rentals booking and management.
+A payments service is not implemented and related configuration has been removed.
+
 ## Development
 
 Install dependencies and start the server:
@@ -19,5 +18,3 @@ npm start
 ```
 
 The server runs from `index.js` on port `3000` by default and exposes API docs at `http://localhost:3000/docs`.
-
-


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers
- clarify available services and streamline documentation

## Testing
- `cd api && npm install`
- `npm test` *(fails: jest not found)*
- `npm run test:integration` *(fails: newman not found)*
- `npm run test:contract` *(fails: newman not found)*
- `cd ui && npm install`
- `npx playwright install chromium` *(fails: download 403)*
- `npm test` *(fails: browser launch error)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ad5874ac83318f32bc06fff7d92a