### PR TITLE
Remove payments configuration from dev environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # HomestaysOfHimalaya
 
-Himalayan Homestays , bike & car rentals booking and management.
+Himalayan Homestays, bike & car rentals booking and management.
 
 ## Services
 - Booking service
 - User service
 
-A payments service is currently not implemented and related configuration has been removed.
-=======
-Himalayan Homestays , bike &amp; car rentals booking and management.
+A payments service is currently not implemented and related configuration has been removed from all development environments.
+
 ## Development
 
 Install dependencies and start the server:
@@ -19,5 +18,4 @@ npm start
 ```
 
 The server runs from `index.js` on port `3000` by default and exposes API docs at `http://localhost:3000/docs`.
-
 

--- a/config/dev-integration.yml
+++ b/config/dev-integration.yml
@@ -2,9 +2,6 @@ booking:
   database_url: "/homestaysofhimalaya/dev-integration/booking/database_url"
   redis_url: "/homestaysofhimalaya/dev-integration/booking/redis_url"
 
-payments:
-  database_url: "/homestaysofhimalaya/dev-integration/payments/database_url"
-  redis_url: "/homestaysofhimalaya/dev-integration/payments/redis_url"
 users:
   database_url: "/homestaysofhimalaya/dev-integration/users/database_url"
   redis_url: "/homestaysofhimalaya/dev-integration/users/redis_url"

--- a/config/dev-production.yml
+++ b/config/dev-production.yml
@@ -1,9 +1,7 @@
 booking:
   database_url: "/homestaysofhimalaya/dev-production/booking/database_url"
   redis_url: "/homestaysofhimalaya/dev-production/booking/redis_url"
-payments:
-  database_url: "/homestaysofhimalaya/dev-production/payments/database_url"
-  redis_url: "/homestaysofhimalaya/dev-production/payments/redis_url"
+
 users:
   database_url: "/homestaysofhimalaya/dev-production/users/database_url"
   redis_url: "/homestaysofhimalaya/dev-production/users/redis_url"

--- a/config/dev-staging.yml
+++ b/config/dev-staging.yml
@@ -2,9 +2,6 @@ booking:
   database_url: "/homestaysofhimalaya/dev-staging/booking/database_url"
   redis_url: "/homestaysofhimalaya/dev-staging/booking/redis_url"
 
-payments:
-  database_url: "/homestaysofhimalaya/dev-staging/payments/database_url"
-  redis_url: "/homestaysofhimalaya/dev-staging/payments/redis_url"
 users:
   database_url: "/homestaysofhimalaya/dev-staging/users/database_url"
   redis_url: "/homestaysofhimalaya/dev-staging/users/redis_url"


### PR DESCRIPTION
## Summary
- remove `payments` block from dev integration, staging, and production config files
- note in README that no payments configuration is present

## Testing
- `npm test` (No tests)
- `node -e "const yaml=require('js-yaml'),fs=require('fs');['config/dev-integration.yml','config/dev-production.yml','config/dev-staging.yml'].forEach(f=>{yaml.load(fs.readFileSync(f,'utf8')); console.log(f+' loaded')});"`
- `cd api && npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `cd api && npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ad5fb3c08331915ac7b4eed038d9