### PR TITLE
Use index.js in start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "commonjs",
   "scripts": {
 
-    "start": "node server.js",
+    "start": "node index.js",
     "docs": "redoc-cli bundle api/openapi.yaml -o docs/index.html",
 
     "test": "node -e \"console.log('No tests')\""


### PR DESCRIPTION
## Summary
- fix start script to run index.js

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6c19ca1108331baf02c9a0771ab43