### PR TITLE
Remove unused Jest configuration in API

### DIFF
--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  testMatch: ['**/tests/unit/**/*.test.js']
-};

--- a/api/package.json
+++ b/api/package.json
@@ -2,12 +2,11 @@
   "name": "api",
   "version": "1.0.0",
   "scripts": {
-    "test": "jest",
+    "test": "pytest tests/unit",
     "test:integration": "newman run tests/integration/echo.postman_collection.json",
     "test:contract": "newman run tests/contract/contract.postman_collection.json"
   },
   "devDependencies": {
-    "jest": "^29.0.0",
     "newman": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- remove obsolete Jest config from API
- run API unit tests with pytest via npm test script

## Testing
- `cd api && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6c325eac88331a8bb11b83cfce8c2