### PR TITLE
ci: add node test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,27 @@ jobs:
           python-version: '3.x'
       - run: pip install bandit
       - run: bandit -r .
+
+  node-tests:
+    runs-on: ubuntu-latest
+    needs: security
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: npm install
+      - run: npm test
+      - run: |
+          cd api
+          npm install
+          pip install -r ../services/booking/requirements.txt -r ../services/users/requirements.txt pytest
+          npm test
+      - run: |
+          cd ui
+          npm install
+          npx playwright install chromium
+          npm test


### PR DESCRIPTION
## Summary
- add node tests job running npm install and npm test for root, api, and ui

## Testing
- `npm test`
- `cd api && npm test`
- `cd ui && npm test` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c41bd2ec833193978dba73ff9acc