### PR TITLE
Scaffold payments microservice

### DIFF
--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -24,6 +24,12 @@ For example, the booking service database URL for the integration environment is
 /homestaysofhimalaya/dev-integration/booking/database_url
 ```
 
+Similarly, the payments service database URL for the integration environment is stored at:
+
+```
+/homestaysofhimalaya/dev-integration/payments/database_url
+```
+
 Parameters should be created with `--type SecureString` for sensitive values.
 
 ## Using Configuration
@@ -35,6 +41,12 @@ To start the booking service in the staging environment:
 
 ```bash
 APP_ENV=dev-staging services/booking/start.sh
+```
+
+To start the payments service in the staging environment:
+
+```bash
+APP_ENV=dev-staging services/payments/start.sh
 ```
 
 Ensure the IAM role or AWS credentials used by the service allow `ssm:GetParameter` access.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@ Himalayan Homestays, bike & car rentals booking and management.
 ## Services
 - Booking service
 - User service
-
-
-A payments service is currently not implemented and related configuration has been removed from all development environments.
+- Payment service
 
 
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -26,3 +26,8 @@ def booking_module():
 @pytest.fixture(scope="module")
 def users_module():
     return load_service_module('users')
+
+
+@pytest.fixture(scope="module")
+def payments_module():
+    return load_service_module('payments')

--- a/api/tests/integration/test_service_routes.py
+++ b/api/tests/integration/test_service_routes.py
@@ -2,15 +2,19 @@ import logging
 import asyncio
 
 
-def test_booking_and_user_services_integration(booking_module, users_module, caplog):
+def test_booking_user_and_payments_services_integration(booking_module, users_module, payments_module, caplog):
     booking_routes = [route.path for route in booking_module.app.routes]
     users_routes = [route.path for route in users_module.app.routes]
+    payments_routes = [route.path for route in payments_module.app.routes]
     assert "/" in booking_routes
     assert "/" in users_routes
+    assert "/" in payments_routes
     with caplog.at_level(logging.INFO):
         booking_result = asyncio.run(booking_module.root())
         users_result = asyncio.run(users_module.root())
+        payments_result = asyncio.run(payments_module.root())
     assert booking_result["service"] == "booking"
     assert users_result["service"] == "user"
+    assert payments_result["service"] == "payment"
     services_logged = {getattr(record, "service", None) for record in caplog.records if record.message == "root accessed"}
-    assert services_logged == {"booking", "user"}
+    assert services_logged == {"booking", "user", "payment"}

--- a/api/tests/unit/test_payments_app.py
+++ b/api/tests/unit/test_payments_app.py
@@ -1,0 +1,12 @@
+import logging
+import asyncio
+
+
+def test_payments_root_endpoint_and_logging(payments_module, caplog):
+    app = payments_module.app
+    routes = [route.path for route in app.routes]
+    assert "/" in routes
+    with caplog.at_level(logging.INFO):
+        result = asyncio.run(payments_module.root())
+    assert result == {"service": "payment", "message": "Hello World"}
+    assert any(record.message == "root accessed" and getattr(record, "service", None) == "payment" for record in caplog.records)

--- a/config/dev-integration.yml
+++ b/config/dev-integration.yml
@@ -6,3 +6,7 @@ users:
   database_url: "/homestaysofhimalaya/dev-integration/users/database_url"
   redis_url: "/homestaysofhimalaya/dev-integration/users/redis_url"
 
+payments:
+  database_url: "/homestaysofhimalaya/dev-integration/payments/database_url"
+  redis_url: "/homestaysofhimalaya/dev-integration/payments/redis_url"
+

--- a/config/dev-production.yml
+++ b/config/dev-production.yml
@@ -6,3 +6,7 @@ users:
   database_url: "/homestaysofhimalaya/dev-production/users/database_url"
   redis_url: "/homestaysofhimalaya/dev-production/users/redis_url"
 
+payments:
+  database_url: "/homestaysofhimalaya/dev-production/payments/database_url"
+  redis_url: "/homestaysofhimalaya/dev-production/payments/redis_url"
+

--- a/config/dev-staging.yml
+++ b/config/dev-staging.yml
@@ -6,3 +6,7 @@ users:
   database_url: "/homestaysofhimalaya/dev-staging/users/database_url"
   redis_url: "/homestaysofhimalaya/dev-staging/users/redis_url"
 
+payments:
+  database_url: "/homestaysofhimalaya/dev-staging/payments/database_url"
+  redis_url: "/homestaysofhimalaya/dev-staging/payments/redis_url"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,15 @@ services:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
 
+  payments:
+    build: ./services/payments
+    ports:
+      - "8002:8000"
+    environment:
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+
   web:
     image: node:20
     working_dir: /app

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,8 +14,7 @@
 3. Access the services:
    - Booking service: `http://localhost:8000`
    - User service: `http://localhost:8001`
-
-The payments service has been removed from this project.
+   - Payment service: `http://localhost:8002`
 
 Logs are emitted in JSON format and, when AWS credentials are available, forwarded to CloudWatch.
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,7 +5,7 @@ echo "Setting up development environment..."
 
 python3 -m venv venv
 source venv/bin/activate
-pip install -r services/booking/requirements.txt -r services/users/requirements.txt
+pip install -r services/booking/requirements.txt -r services/users/requirements.txt -r services/payments/requirements.txt
 
 echo "Building and starting services with Docker Compose..."
 docker compose up --build -d

--- a/services/payments/Dockerfile
+++ b/services/payments/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+EXPOSE 8000
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/payments/app.py
+++ b/services/payments/app.py
@@ -1,0 +1,29 @@
+import logging
+from fastapi import FastAPI
+from pythonjsonlogger import jsonlogger
+import watchtower
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+stream_handler = logging.StreamHandler()
+stream_handler.setFormatter(jsonlogger.JsonFormatter())
+logger.addHandler(stream_handler)
+
+try:
+    cw_handler = watchtower.CloudWatchLogHandler(log_group="/homestays/services", stream_name="payment-service")
+    cw_handler.setFormatter(jsonlogger.JsonFormatter())
+    logger.addHandler(cw_handler)
+except Exception as e:
+    logger.warning("Unable to initialize CloudWatch log handler", extra={"error": str(e)})
+
+app = FastAPI()
+
+@app.get("/")
+async def root():
+    logger.info("root accessed", extra={"service": "payment"})
+    return {"service": "payment", "message": "Hello World"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/payments/requirements.txt
+++ b/services/payments/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+watchtower
+python-json-logger

--- a/services/payments/start.sh
+++ b/services/payments/start.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_ENV="${APP_ENV:-dev-integration}"
+"${SCRIPT_DIR}/../../scripts/start_service.sh" payments "$@"


### PR DESCRIPTION
## Summary
- add FastAPI-based payments service with Docker, requirements and start script
- wire payments service into environment configs, docker-compose, docs and setup
- cover payments service with unit and integration tests

## Testing
- `pip install -r services/payments/requirements.txt`
- `pytest api/tests`


------
https://chatgpt.com/codex/tasks/task_e_68b6c505414c833192fd83e9e347f6da