### PR TITLE
Start services with uvicorn

### DIFF
--- a/scripts/start_service.sh
+++ b/scripts/start_service.sh
@@ -35,5 +35,5 @@ REDIS_URL=$(aws ssm get-parameter --name "$REDIS_PARAM" --with-decryption --outp
 export DB_URL REDIS_URL
 
 echo "Starting $SERVICE with configuration from $CONFIG_FILE"
-# Placeholder for actual service command
-exec "./$SERVICE" "$@"
+# Launch the FastAPI service using uvicorn
+exec uvicorn app:app --host 0.0.0.0 --port 8000 "$@"


### PR DESCRIPTION
## Summary
- launch services using uvicorn instead of service executables

## Testing
- `npm test`
- `PATH="/tmp:$PATH" services/booking/start.sh`
- `PATH="/tmp:$PATH" services/payments/start.sh`
- `PATH="/tmp:$PATH" services/users/start.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b6cade0b248331b6e2628f997a8c98