### PR TITLE
Add basic route and auth tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,10 @@ app.get('/payments', async (req, res) => {
 });
 
 const port = process.env.PORT || 3000;
-app.listen(port, () => {
-  console.log(`Server running on port ${port}`);
-});
+if (require.main === module) {
+  app.listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+}
+
+module.exports = app;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "node index.js",
     "docs": "redoc-cli bundle api/openapi.yaml -o docs/index.html",
 
-    "test": "node -e \"console.log('No tests')\""
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/tests/routes.test.js
+++ b/tests/routes.test.js
@@ -1,0 +1,53 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const app = require('../index');
+
+let server;
+
+const baseUrl = () => `http://localhost:${server.address().port}`;
+
+// Start server before tests
+
+test.before(() => {
+  server = http.createServer(app);
+  return new Promise((resolve) => server.listen(0, resolve));
+});
+
+// Close server after tests
+
+test.after(() => {
+  return new Promise((resolve) => server.close(resolve));
+});
+
+test('rejects unauthorized requests', async () => {
+  const res = await fetch(`${baseUrl()}/homestays`);
+  assert.equal(res.status, 401);
+});
+
+test('allows requests with valid API key', async () => {
+  const res = await fetch(`${baseUrl()}/homestays`, {
+    headers: { 'x-api-key': process.env.API_KEY || 'dev-key' }
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.deepStrictEqual(body, [
+    { id: 1, name: 'Sample Homestay', location: 'Himalaya' }
+  ]);
+});
+
+test('allows requests with valid bearer token', async () => {
+  const res = await fetch(`${baseUrl()}/homestays`, {
+    headers: { Authorization: `Bearer ${process.env.OAUTH_TOKEN || 'dev-token'}` }
+  });
+  assert.equal(res.status, 200);
+});
+
+test('returns stub data for bookings service', async () => {
+  const res = await fetch(`${baseUrl()}/bookings`, {
+    headers: { 'x-api-key': process.env.API_KEY || 'dev-key' }
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.deepStrictEqual(body, { service: 'booking', message: 'Hello World' });
+});


### PR DESCRIPTION
## Summary
- export Express app and guard server start
- add Node test runner script
- add tests covering auth and booking route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6cc3d590483318e2cc94e893e87ae