### PR TITLE
Include payments requirements in node tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - run: |
           cd api
           npm install
-          pip install -r ../services/booking/requirements.txt -r ../services/users/requirements.txt pytest
+          pip install -r ../services/booking/requirements.txt -r ../services/users/requirements.txt -r ../services/payments/requirements.txt pytest
           npm test
       - run: |
           cd ui


### PR DESCRIPTION
## Summary
- ensure node-tests job installs payments service requirements

## Testing
- `npm test`
- `cd api && npm test`
- `cd ui && npx playwright install chromium` *(fails: Download failed: server returned code 403)*
- `cd ui && npm test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68b6cec95fcc833192aeca2475de1466