### PR TITLE
chore(api): remove unused contract test script

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -14,10 +14,6 @@
    ```bash
    npm run test:integration
    ```
-4. Run contract tests:
-   ```bash
-   npm run test:contract
-   ```
 
 ## UI Tests
 1. Install dependencies:

--- a/api/package.json
+++ b/api/package.json
@@ -3,8 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "test": "pytest tests/unit",
-    "test:integration": "newman run tests/integration/echo.postman_collection.json",
-    "test:contract": "newman run tests/contract/contract.postman_collection.json"
+    "test:integration": "newman run tests/integration/echo.postman_collection.json"
   },
   "devDependencies": {
     "newman": "^5.0.0"


### PR DESCRIPTION
## Summary
- remove unused `test:contract` script from the API
- drop contract test instructions from the testing guide

## Testing
- `npm test`
- `npm run test:integration` *(fails: collection could not be loaded)*

------
https://chatgpt.com/codex/tasks/task_e_68b6cecd842c83318bf11360d7685ba3