### PR TITLE
chore: fix integration test script

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "scripts": {
     "test": "pytest tests/unit",
-    "test:integration": "newman run tests/integration/echo.postman_collection.json"
-  },
-  "devDependencies": {
-    "newman": "^5.0.0"
+    "test:integration": "pytest tests/integration"
   }
 }


### PR DESCRIPTION
## Summary
- replace missing Postman collection command with pytest-based integration tests

## Testing
- `npm test`
- `npm run test:integration`


------
https://chatgpt.com/codex/tasks/task_e_68b6d11fe8d88331a54c9ffd069e772e