### PR TITLE
chore: align CI Node version with Docker env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'


### PR DESCRIPTION
## Summary
- update node-tests job to use Node.js v20

## Testing
- `npm test`
- `cd api && npm test`
- `cd ui && npm test` *(fails: Executable doesn't exist; requires `npx playwright install` but download was forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d1ef9af083318b191d8bb330f2bd