### PR TITLE
feat: enforce Node 18 and polyfill fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ npm start
 
 The server runs from `index.js` on port `3000` by default and exposes API docs at `http://localhost:3000/docs`.
 
+### Requirements
+
+This project requires **Node.js 18 or later** for native `fetch` support. For older Node versions, `node-fetch` is automatically loaded as a polyfill when `fetch` is unavailable.
+

--- a/index.js
+++ b/index.js
@@ -11,6 +11,11 @@ const path = require('path');
 const yaml = require('js-yaml');
 const swaggerUi = require('swagger-ui-express');
 
+if (!globalThis.fetch) {
+  globalThis.fetch = (...args) =>
+    import('node-fetch').then(({ default: fetch }) => fetch(...args));
+}
+
 const app = express();
 const spec = yaml.load(fs.readFileSync(path.join(__dirname, 'api/openapi.yaml'), 'utf8'));
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Uttarakhand homestays bookings & rentals API with OpenAPI docs",
   "main": "index.js",
   "type": "commonjs",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
 
     "start": "node index.js",
@@ -18,7 +21,8 @@
     "express": "^4.18.2",
     "swagger-ui-express": "^4.6.3",
     "js-yaml": "^4.1.0",
-    "dd-trace": "^5.9.0"
+    "dd-trace": "^5.9.0",
+    "node-fetch": "^3.3.2"
   },
   "devDependencies": {
     "redoc-cli": "^0.13.14"

--- a/tests/routes.test.js
+++ b/tests/routes.test.js
@@ -3,6 +3,11 @@ const assert = require('node:assert/strict');
 const http = require('node:http');
 const app = require('../index');
 
+if (!globalThis.fetch) {
+  globalThis.fetch = (...args) =>
+    import('node-fetch').then(({ default: fetch }) => fetch(...args));
+}
+
 let server;
 
 const baseUrl = () => `http://localhost:${server.address().port}`;


### PR DESCRIPTION
## Summary
- specify Node.js >=18 engine and add node-fetch dependency
- polyfill fetch in server and tests when unavailable
- document Node version requirement and automatic polyfill

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/node-fetch)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d5b96c10833195e82622119763cb