### PR TITLE
Check dependencies before launching services

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ npm start
 
 The server runs from `index.js` on port `3000` by default and exposes API docs at `http://localhost:3000/docs`.
 
+
+## Scripts
+
+The `scripts/start_service.sh` script requires the AWS CLI and Python with the `PyYAML` package installed.

--- a/scripts/start_service.sh
+++ b/scripts/start_service.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# start_service.sh - Launch a service with configuration from AWS SSM
+# Requires: AWS CLI and Python with the PyYAML package installed.
+
 set -euo pipefail
 
 SERVICE="$1"
@@ -8,6 +11,16 @@ CONFIG_FILE="config/${APP_ENV}.yml"
 
 if [ ! -f "$CONFIG_FILE" ]; then
   echo "Config file $CONFIG_FILE not found" >&2
+  exit 1
+fi
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "Error: aws CLI is required but not installed." >&2
+  exit 1
+fi
+
+if ! python -c "import yaml" >/dev/null 2>&1; then
+  echo "Error: Python with PyYAML is required but not installed." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Ensure `scripts/start_service.sh` validates availability of aws CLI and Python with PyYAML
- Document these script prerequisites in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6d5cf01188331bbe1c594380aeb5e