### PR TITLE
docs: document python dependencies for tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -3,8 +3,13 @@
 ## API
 1. Install dependencies:
    ```bash
+   pip install -r services/requirements.txt
    cd api
    npm install
+   ```
+   Alternatively, install each service dependency separately:
+   ```bash
+   pip install -r services/booking/requirements.txt -r services/users/requirements.txt -r services/payments/requirements.txt
    ```
 2. Run unit tests:
    ```bash

--- a/services/requirements.txt
+++ b/services/requirements.txt
@@ -1,0 +1,3 @@
+-r booking/requirements.txt
+-r users/requirements.txt
+-r payments/requirements.txt


### PR DESCRIPTION
## Summary
- note that Python service dependencies must be installed before running API tests
- add combined `services/requirements.txt` to simplify installing dependencies

## Testing
- `pip install -r services/requirements.txt`
- `cd api && npm test`
- `cd api && npm run test:integration`


------
https://chatgpt.com/codex/tasks/task_e_68b6d5d02a2483318a6c83cc53802b87